### PR TITLE
Add <p> on summary

### DIFF
--- a/views/front/post/summary.view.php
+++ b/views/front/post/summary.view.php
@@ -11,7 +11,7 @@
 if ($blognews_config['summary']['enabled'] && $blognews_config['summary']['show']) {
     ?>
     <div class="blognews_summary">
-        <?= nl2br(e($item->post_summary)) ?>
+        <p><?= nl2br(e($item->post_summary)) ?></p>
     </div>
     <?php
 }


### PR DESCRIPTION
The content has "p" by default because it parses wysiwyg. So, the summary must have "p" ! Logic !
