### PR TITLE
Update Front.ctrl.php getUrlEnhanced()

### DIFF
--- a/classes/controller/front.ctrl.php
+++ b/classes/controller/front.ctrl.php
@@ -642,7 +642,7 @@ class Controller_Front extends Controller_Front_Application
                 case static::$post_class:
                     $enhancer_args = \Arr::get($params, 'enhancer_args', array());
                     $cat_ids = (array) \Arr::get($enhancer_args, 'cat_id', array());
-                    if (!empty($cat_ids)) {
+                    if (count(array_filter($cat_ids)) > 0) {
                         $intersect = array_intersect($cat_ids, array_keys($item->categories));
                         if (empty($intersect)) {
                             return false;


### PR DESCRIPTION
Dans mon BO, la racine est sélectionnée, et mon $cat_ids de la ligne 644 renvoie :
Array
(
    [0] => 0
)

du coup getUrlEnhanced retourne false, et donc $item->url() retourne null.
