### PR TITLE
Fix duplicate content for an enhancer that displays a single category

### DIFF
--- a/classes/controller/front.ctrl.php
+++ b/classes/controller/front.ctrl.php
@@ -172,6 +172,11 @@ class Controller_Front extends Controller_Front_Application
 
                 return $this->display_list_tag($args);
             } elseif ($segments[0] === 'category') {
+                if (!empty($args['cat_id'])) {
+                    // Redirects to the main listing if a category is selected to prevent duplicate content
+                    \Response::redirect($this->main_controller->getContextUrl().$this->main_controller->getPageUrl(), 'location', 301);
+                    exit;
+                }
                 $this->init_pagination(!empty($segments[2]) ? $segments[2] : 1);
 
                 return $this->display_list_category($args);


### PR DESCRIPTION
When the enhancer displays a single category, there is a duplicate content between the main listing and the listing by category, as they both lists the same posts with the same view.

The fix consists of adding a 301 redirect on the listing by category that points to the main listing when a single category is displayed by the enhancer.